### PR TITLE
Update the Publisher and Subscriber constructor

### DIFF
--- a/pkg/kafka/pubsub_bench_test.go
+++ b/pkg/kafka/pubsub_bench_test.go
@@ -15,7 +15,10 @@ func BenchmarkSubscriber(b *testing.B) {
 	tests.BenchSubscriber(b, func(n int) (message.Publisher, message.Subscriber) {
 		logger := watermill.NopLogger{}
 
-		publisher, err := kafka.NewPublisher(kafkaBrokers(), kafka.DefaultMarshaler{}, nil, logger)
+		publisher, err := kafka.NewPublisher(kafka.PublisherConfig{
+			Brokers:   kafkaBrokers(),
+			Marshaler: kafka.DefaultMarshaler{},
+		}, logger)
 		if err != nil {
 			panic(err)
 		}
@@ -25,11 +28,11 @@ func BenchmarkSubscriber(b *testing.B) {
 
 		subscriber, err := kafka.NewSubscriber(
 			kafka.SubscriberConfig{
-				Brokers:       kafkaBrokers(),
-				ConsumerGroup: "test",
+				Brokers:               kafkaBrokers(),
+				Unmarshaler:           kafka.DefaultMarshaler{},
+				OverwriteSaramaConfig: saramaConfig,
+				ConsumerGroup:         "test",
 			},
-			saramaConfig,
-			kafka.DefaultMarshaler{},
 			logger,
 		)
 		if err != nil {

--- a/pkg/kafka/subscriber.go
+++ b/pkg/kafka/subscriber.go
@@ -15,11 +15,8 @@ import (
 )
 
 type Subscriber struct {
-	config       SubscriberConfig
-	saramaConfig *sarama.Config
-
-	unmarshaler Unmarshaler
-	logger      watermill.LoggerAdapter
+	config SubscriberConfig
+	logger watermill.LoggerAdapter
 
 	closing       chan struct{}
 	subscribersWg sync.WaitGroup
@@ -30,18 +27,12 @@ type Subscriber struct {
 // NewSubscriber creates a new Kafka Subscriber.
 func NewSubscriber(
 	config SubscriberConfig,
-	overwriteSaramaConfig *sarama.Config,
-	unmarshaler Unmarshaler,
 	logger watermill.LoggerAdapter,
 ) (message.Subscriber, error) {
 	config.setDefaults()
 
 	if err := config.Validate(); err != nil {
 		return nil, err
-	}
-
-	if overwriteSaramaConfig == nil {
-		overwriteSaramaConfig = DefaultSaramaSubscriberConfig()
 	}
 
 	if logger == nil {
@@ -53,11 +44,8 @@ func NewSubscriber(
 	})
 
 	return &Subscriber{
-		config:       config,
-		saramaConfig: overwriteSaramaConfig,
-
-		unmarshaler: unmarshaler,
-		logger:      logger,
+		config: config,
+		logger: logger,
 
 		closing: make(chan struct{}),
 	}, nil
@@ -66,6 +54,12 @@ func NewSubscriber(
 type SubscriberConfig struct {
 	// Kafka brokers list.
 	Brokers []string
+
+	// Unmarshaler is used to unmarshal messages from Kafka format into Watermill format.
+	Unmarshaler Unmarshaler
+
+	// OverwriteSaramaConfig holds additional sarama settings.
+	OverwriteSaramaConfig *sarama.Config
 
 	// Kafka consumer group.
 	// When empty, all messages from all partitions will be returned.
@@ -84,6 +78,9 @@ type SubscriberConfig struct {
 const NoSleep time.Duration = -1
 
 func (c *SubscriberConfig) setDefaults() {
+	if c.OverwriteSaramaConfig == nil {
+		c.OverwriteSaramaConfig = DefaultSaramaSubscriberConfig()
+	}
 	if c.NackResendSleep == 0 {
 		c.NackResendSleep = time.Millisecond * 100
 	}
@@ -95,6 +92,9 @@ func (c *SubscriberConfig) setDefaults() {
 func (c SubscriberConfig) Validate() error {
 	if len(c.Brokers) == 0 {
 		return errors.New("missing brokers")
+	}
+	if c.Unmarshaler == nil {
+		return errors.New("missing unmarshaler")
 	}
 
 	return nil
@@ -190,7 +190,7 @@ func (s *Subscriber) consumeMessages(
 	s.logger.Info("Starting consuming", logFields)
 
 	// Start with a client
-	client, err := sarama.NewClient(s.config.Brokers, s.saramaConfig)
+	client, err := sarama.NewClient(s.config.Brokers, s.config.OverwriteSaramaConfig)
 	if err != nil {
 		return nil, errors.Wrap(err, "cannot create new Sarama client")
 	}
@@ -308,7 +308,7 @@ func (s *Subscriber) consumeWithoutConsumerGroups(
 	for _, partition := range partitions {
 		partitionLogFields := logFields.Add(watermill.LogFields{"kafka_partition": partition})
 
-		partitionConsumer, err := consumer.ConsumePartition(topic, partition, s.saramaConfig.Consumer.Offsets.Initial)
+		partitionConsumer, err := consumer.ConsumePartition(topic, partition, s.config.OverwriteSaramaConfig.Consumer.Offsets.Initial)
 		if err != nil {
 			if err := client.Close(); err != nil && err != sarama.ErrClosedClient {
 				s.logger.Error("Cannot close client", err, partitionLogFields)
@@ -373,7 +373,7 @@ func (s *Subscriber) consumePartition(
 func (s *Subscriber) createMessagesHandler(output chan *message.Message) messageHandler {
 	return messageHandler{
 		outputChannel:   output,
-		unmarshaler:     s.unmarshaler,
+		unmarshaler:     s.config.Unmarshaler,
 		nackResendSleep: s.config.NackResendSleep,
 		logger:          s.logger,
 		closing:         s.closing,
@@ -520,7 +520,7 @@ func (s *Subscriber) SubscribeInitialize(topic string) (err error) {
 		return errors.New("s.config.InitializeTopicDetails is empty, cannot SubscribeInitialize")
 	}
 
-	clusterAdmin, err := sarama.NewClusterAdmin(s.config.Brokers, s.saramaConfig)
+	clusterAdmin, err := sarama.NewClusterAdmin(s.config.Brokers, s.config.OverwriteSaramaConfig)
 	if err != nil {
 		return errors.Wrap(err, "cannot create cluster admin")
 	}


### PR DESCRIPTION
**Note: this introduces breaking changes and will require major version bump.**

This change introduces consistent `NewPublisher` and `NewSubscriber` definitions, along with a `PublisherConfig`.

This is to keep the constructors consistent with other Pub/Sub implementations. Also, the Kafka Publisher lacked a config structure, so adding any new features would require changing the API.

Sadly, this means breaking changes and will require releasing 2.0.0 of watermill-kafka.