### PR TITLE
expose kafka offset data through message context

### DIFF
--- a/pkg/kafka/context.go
+++ b/pkg/kafka/context.go
@@ -8,39 +8,18 @@ type contextKey int
 
 const (
 	_ contextKey = iota
-	topicContextKey
 	partitionContextKey
 	partitionOffsetContextKey
 )
-
-func setTopicToCtx(ctx context.Context, topic string) context.Context {
-	return context.WithValue(ctx, topicContextKey, topic)
-}
-
-// MessageTopicFromCtx returns kafka topic of consumed message
-func MessageTopicFromCtx(ctx context.Context) string {
-	topic := ctx.Value(topicContextKey)
-
-	if stringTopic, ok := topic.(string); ok {
-		return stringTopic
-	} else {
-		return ""
-	}
-}
 
 func setPartitionToCtx(ctx context.Context, partition int32) context.Context {
 	return context.WithValue(ctx, partitionContextKey, partition)
 }
 
 // MessagePartitionFromCtx returns kafka partition of consumed message
-func MessagePartitionFromCtx(ctx context.Context) int32 {
-	partition := ctx.Value(partitionContextKey)
-
-	if intPartition, ok := partition.(int32); ok {
-		return intPartition
-	} else {
-		return 0
-	}
+func MessagePartitionFromCtx(ctx context.Context) (int32, bool) {
+	partition, ok := ctx.Value(partitionContextKey).(int32)
+	return partition, ok
 }
 
 func setPartitionOffsetToCtx(ctx context.Context, offset int64) context.Context {
@@ -48,12 +27,7 @@ func setPartitionOffsetToCtx(ctx context.Context, offset int64) context.Context 
 }
 
 // MessagePartitionFromCtx returns kafka partition offset of consumed message
-func MessagePartitionOffsetFromCtx(ctx context.Context) int64 {
-	partitionOffset := ctx.Value(partitionOffsetContextKey)
-
-	if intPartitionOffset, ok := partitionOffset.(int64); ok {
-		return intPartitionOffset
-	} else {
-		return 0
-	}
+func MessagePartitionOffsetFromCtx(ctx context.Context) (int64, bool) {
+	offset, ok := ctx.Value(partitionOffsetContextKey).(int64)
+	return offset, ok
 }

--- a/pkg/kafka/context.go
+++ b/pkg/kafka/context.go
@@ -1,0 +1,59 @@
+package kafka
+
+import (
+	"context"
+)
+
+type contextKey int
+
+const (
+	_ contextKey = iota
+	topicContextKey
+	partitionContextKey
+	partitionOffsetContextKey
+)
+
+func setTopicToCtx(ctx context.Context, topic string) context.Context {
+	return context.WithValue(ctx, topicContextKey, topic)
+}
+
+// MessageTopicFromCtx returns kafka topic of consumed message
+func MessageTopicFromCtx(ctx context.Context) string {
+	topic := ctx.Value(topicContextKey)
+
+	if stringTopic, ok := topic.(string); ok {
+		return stringTopic
+	} else {
+		return ""
+	}
+}
+
+func setPartitionToCtx(ctx context.Context, partition int32) context.Context {
+	return context.WithValue(ctx, partitionContextKey, partition)
+}
+
+// MessagePartitionFromCtx returns kafka partition of consumed message
+func MessagePartitionFromCtx(ctx context.Context) int32 {
+	partition := ctx.Value(partitionContextKey)
+
+	if intPartition, ok := partition.(int32); ok {
+		return intPartition
+	} else {
+		return 0
+	}
+}
+
+func setPartitionOffsetToCtx(ctx context.Context, offset int64) context.Context {
+	return context.WithValue(ctx, partitionOffsetContextKey, offset)
+}
+
+// MessagePartitionFromCtx returns kafka partition offset of consumed message
+func MessagePartitionOffsetFromCtx(ctx context.Context) int64 {
+	partitionOffset := ctx.Value(partitionOffsetContextKey)
+
+	if intPartitionOffset, ok := partitionOffset.(int64); ok {
+		return intPartitionOffset
+	} else {
+		return 0
+	}
+}

--- a/pkg/kafka/publisher.go
+++ b/pkg/kafka/publisher.go
@@ -22,7 +22,7 @@ type Publisher struct {
 func NewPublisher(
 	config PublisherConfig,
 	logger watermill.LoggerAdapter,
-) (message.Publisher, error) {
+) (*Publisher, error) {
 	config.setDefaults()
 
 	if err := config.Validate(); err != nil {

--- a/pkg/kafka/subscriber.go
+++ b/pkg/kafka/subscriber.go
@@ -507,7 +507,6 @@ func (h messageHandler) processMessage(
 
 	h.logger.Trace("Received message from Kafka", receivedMsgLogFields)
 
-	ctx = setTopicToCtx(ctx, kafkaMsg.Topic)
 	ctx = setPartitionToCtx(ctx, kafkaMsg.Partition)
 	ctx = setPartitionOffsetToCtx(ctx, kafkaMsg.Offset)
 


### PR DESCRIPTION
fixes https://github.com/ThreeDotsLabs/watermill/issues/69

Adding Kafka offset data to message context and adding the APIs to retrieve them. Also adding `PartitionOffset` to `Subscriber` to read the latest offsets of a topic.

This is how I have used it:
```go
func NewReadyByNewestOffset(client PartitionOffseter, topics []string) (*ReadyByNewestOffset, error) {
	pss := partitionStatuses{
		partitions:      make(map[string]map[int32]partitionStatus),
		totalPartitions: atomic.NewInt32(0),
		readyPartitions: atomic.NewInt32(0),
	}
	for _, topic := range topics {
		partitionOffset, err := client.PartitionOffset(topic)
		if err != nil {
			return nil, fmt.Errorf("failed to fetch partition info of '%v': %w", topic, err)
		}

		pss.partitions[topic] = make(map[int32]partitionStatus)

		for partition, offset := range partitionOffset {
			// offset will be the offset of the next published message in that partition
			// so we need to consume upto offset - 1
			requiredOffset := offset - 1
			pss.add(topic, partition, requiredOffset)
		}
	}

	return &ReadyByNewestOffset{
		partitionStatuses: pss,

		ready: make(chan struct{}),
		init:  atomic.NewBool(false),
	}, nil
}

// Middleware implements Watermill middleware interface
func (m *ReadyByNewestOffset) Middleware(h message.HandlerFunc) message.HandlerFunc {
	return func(message *message.Message) ([]*message.Message, error) {
		if !m.isReady() {
			ctx := message.Context()
			partition, partitionLoaded := kafka.MessagePartitionFromCtx(ctx)
			offset, offsetLoaded := kafka.MessagePartitionOffsetFromCtx(ctx)

			if partitionLoaded && offsetLoaded {
				m.partitionStatuses.update(message.SubscribeTopicFromCtx(ctx), partition, offset)
			}
		}

		return h(message)
	}
}

// Ready will return a channel which will be closed when status changes to ready
func (m *ReadyByNewestOffset) Ready() chan struct{} {
	return m.ready
}
```