### PR TITLE
fix/rebalancing

### DIFF
--- a/pkg/kafka/subscriber.go
+++ b/pkg/kafka/subscriber.go
@@ -563,6 +563,9 @@ func (h messageHandler) processMessage(
 	msg.SetContext(ctx)
 	defer cancelCtx()
 
+	// check session has been canceled after rebalancing
+	sessionContext := sess.Context()
+
 	receivedMsgLogFields = receivedMsgLogFields.Add(watermill.LogFields{
 		"message_uuid": msg.UUID,
 	})
@@ -577,6 +580,9 @@ ResendLoop:
 			return nil
 		case <-ctx.Done():
 			h.logger.Trace("Closing, ctx cancelled before sent to consumer", receivedMsgLogFields)
+			return nil
+		case <-sessionContext.Done():
+			h.logger.Trace("Closing, session ctx cancelled before sent to consumer", receivedMsgLogFields)
 			return nil
 		}
 
@@ -602,6 +608,9 @@ ResendLoop:
 			return nil
 		case <-ctx.Done():
 			h.logger.Trace("Closing, ctx cancelled before ack", receivedMsgLogFields)
+			return nil
+		case <-sessionContext.Done():
+			h.logger.Trace("Closing, session ctx cancelled before ack", receivedMsgLogFields)
 			return nil
 		}
 	}

--- a/pkg/kafka/subscriber.go
+++ b/pkg/kafka/subscriber.go
@@ -586,7 +586,12 @@ ResendLoop:
 				if sess.Context().Err() == nil {
 					sess.MarkMessage(kafkaMsg, "")
 				} else {
-					h.logger.Trace("Closing, session ctx cancelled before ack", receivedMsgLogFields)
+					logFields := receivedMsgLogFields.Add(
+						watermill.LogFields{
+							"err": sess.Context().Err().Error(),
+						},
+					)
+					h.logger.Trace("Closing, session ctx cancelled before ack", logFields)
 					return nil
 				}
 			}


### PR DESCRIPTION
Checking that the session context has been canceled. If this is not done, after rebalancing consumer will continue to work, but offset will not be able to commit because of error: 
```
kafka server: The provided member is not known in the current generation
```