### PR TITLE
Patch sarama_kafka rebalance fix

### DIFF
--- a/pkg/kafka/subscriber.go
+++ b/pkg/kafka/subscriber.go
@@ -518,6 +518,10 @@ func (h consumerGroupHandler) ConsumeClaim(sess sarama.ConsumerGroupSession, cla
 		case <-h.ctx.Done():
 			h.logger.Debug("Ctx was cancelled, stopping consumerGroupHandler", logFields)
 			return nil
+
+		case <-sess.Context().Done():
+			h.logger.Debug("Session ctx was cancelled, stopping consumerGroupHandler", logFields)
+			return nil
 		default:
 			continue
 		}


### PR DESCRIPTION
After a rebalance, the receiver keeps receiving messages until its error out, and most of these messages fails to commit.
I fix the ConsumeClaim to return once the consumer session is done.