### PR TITLE
use saram defaults (version = sarama.DefaultVersion)

### DIFF
--- a/pkg/kafka/publisher.go
+++ b/pkg/kafka/publisher.go
@@ -93,7 +93,6 @@ func DefaultSaramaSyncPublisherConfig() *sarama.Config {
 
 	config.Producer.Retry.Max = 10
 	config.Producer.Return.Successes = true
-	config.Version = sarama.V1_0_0_0
 	config.Metadata.Retry.Backoff = time.Second * 2
 	config.ClientID = "watermill"
 

--- a/pkg/kafka/subscriber.go
+++ b/pkg/kafka/subscriber.go
@@ -127,7 +127,6 @@ func (c SubscriberConfig) Validate() error {
 //	// ...
 func DefaultSaramaSubscriberConfig() *sarama.Config {
 	config := sarama.NewConfig()
-	config.Version = sarama.V1_0_0_0
 	config.Consumer.Return.Errors = true
 	config.ClientID = "watermill"
 


### PR DESCRIPTION
### Motivation / Background

watermill-kafka currently overwrites the sarama version from sarama.DefaultVersion to v1.0.

Kafka 4.0 is dropping support for message formats v0 and v1: https://cwiki.apache.org/confluence/display/KAFKA/KIP-724%3A+Drop+support+for+message+formats+v0+and+v1

watermill-kafka should just use the default version of sarama.

### Details

removed the overwrite of the sarama version, leaving the default in place

### Alternative approaches considered (if applicable)

none

### Checklist

The resources of our team are limited. **There are a couple of things that you can do to help us merge your PR faster**:

- [ ] I wrote tests for the changes.
- [x] All tests are passing.
  - If you are testing a Pub/Sub, you can start Docker with `make up`.
  - You can start with `make test_short` for a quick check.
  - If you want to run all tests, use `make test`.
- [x] Code has no breaking changes.
- [ ] _(If applicable)_ documentation on [watermill.io](https://watermill.io/) is updated.
  - Documentation is built in the [github.com/ThreeDotsLabs/watermill/docs](https://github.com/ThreeDotsLabs/watermill/tree/master/docs).
  - You can find development instructions in the [DEVELOP.md](https://github.com/ThreeDotsLabs/watermill/tree/master/docs/DEVELOP.md).
