### PR TITLE
Context aware unmarshalling

### DIFF
--- a/pkg/kafka/marshaler.go
+++ b/pkg/kafka/marshaler.go
@@ -1,6 +1,8 @@
 package kafka
 
 import (
+	"context"
+
 	"github.com/IBM/sarama"
 	"github.com/ThreeDotsLabs/watermill/message"
 	"github.com/pkg/errors"
@@ -21,6 +23,10 @@ type Unmarshaler interface {
 type MarshalerUnmarshaler interface {
 	Marshaler
 	Unmarshaler
+}
+
+type ContextUnmarshaler interface {
+	UnmarshalWithContext(context.Context, *sarama.ConsumerMessage) (*message.Message, error)
 }
 
 type DefaultMarshaler struct{}
@@ -63,6 +69,15 @@ func (DefaultMarshaler) Unmarshal(kafkaMsg *sarama.ConsumerMessage) (*message.Me
 	msg := message.NewMessage(messageID, kafkaMsg.Value)
 	msg.Metadata = metadata
 
+	return msg, nil
+}
+
+func (DefaultMarshaler) UnmarshalWithContext(ctx context.Context, kafkaMsg *sarama.ConsumerMessage) (*message.Message, error) {
+	msg, err := DefaultMarshaler{}.Unmarshal(kafkaMsg)
+	if err != nil {
+		return nil, err
+	}
+	msg.SetContext(ctx)
 	return msg, nil
 }
 

--- a/pkg/kafka/marshaler.go
+++ b/pkg/kafka/marshaler.go
@@ -72,8 +72,8 @@ func (DefaultMarshaler) Unmarshal(kafkaMsg *sarama.ConsumerMessage) (*message.Me
 	return msg, nil
 }
 
-func (DefaultMarshaler) UnmarshalWithContext(ctx context.Context, kafkaMsg *sarama.ConsumerMessage) (*message.Message, error) {
-	msg, err := DefaultMarshaler{}.Unmarshal(kafkaMsg)
+func (m DefaultMarshaler) UnmarshalWithContext(ctx context.Context, kafkaMsg *sarama.ConsumerMessage) (*message.Message, error) {
+	msg, err := m.Unmarshal(kafkaMsg)
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/kafka/marshaler.go
+++ b/pkg/kafka/marshaler.go
@@ -16,6 +16,9 @@ type Marshaler interface {
 }
 
 // Unmarshaler unmarshals Kafka's message to Watermill's message.
+// NOTE: Context set here using the Unmarshal function will not be retained;
+// use ContextUnmarshaler's UnmarshalWithContext function to set context on
+// unmarshal.
 type Unmarshaler interface {
 	Unmarshal(*sarama.ConsumerMessage) (*message.Message, error)
 }
@@ -25,6 +28,10 @@ type MarshalerUnmarshaler interface {
 	Unmarshaler
 }
 
+// ContextUnmarshaler unmarshals Kafka's message to Watermill's message
+// passing the base context into the UnmarshalWithContext function.
+// NOTE: If you are implementing this you MUST set context in this function
+// or it will be lost.
 type ContextUnmarshaler interface {
 	UnmarshalWithContext(context.Context, *sarama.ConsumerMessage) (*message.Message, error)
 }

--- a/pkg/kafka/marshaler_test.go
+++ b/pkg/kafka/marshaler_test.go
@@ -39,16 +39,12 @@ func TestDefaultMarshaler_UnmarshalWithContext(t *testing.T) {
 
 	consumerMsg := producerToConsumerMessage(producerMsg)
 
-	type ctxType string
-
-	const ctxKey ctxType = "test-key"
-	const ctxVal ctxType = "test-value"
-	ctx := context.WithValue(context.Background(), ctxKey, ctxVal)
+	ctx := context.WithValue(context.Background(), ctxType("test-key"), ctxType("test-value"))
 
 	unmarshaled, err := m.UnmarshalWithContext(ctx, consumerMsg)
 	require.NoError(t, err)
 	require.NotNil(t, unmarshaled.Context())
-	assert.Equal(t, ctxVal, unmarshaled.Context().Value(ctxKey))
+	assert.Equal(t, ctxType("test-value"), unmarshaled.Context().Value(ctxType("test-key")))
 
 	assert.True(t, msg.Equals(unmarshaled))
 }

--- a/pkg/kafka/marshaler_test.go
+++ b/pkg/kafka/marshaler_test.go
@@ -1,6 +1,7 @@
 package kafka_test
 
 import (
+	"context"
 	"testing"
 
 	"github.com/IBM/sarama"
@@ -25,6 +26,31 @@ func TestDefaultMarshaler_MarshalUnmarshal(t *testing.T) {
 	require.NoError(t, err)
 
 	assert.True(t, msg.Equals(unmarshaledMsg))
+}
+
+func TestDefaultMarshaler_UnmarshalWithContext(t *testing.T) {
+	m := kafka.DefaultMarshaler{}
+
+	msg := message.NewMessage(watermill.NewUUID(), []byte("payload"))
+	msg.Metadata.Set("foo", "bar")
+
+	producerMsg, err := m.Marshal("topic", msg)
+	require.NoError(t, err)
+
+	consumerMsg := producerToConsumerMessage(producerMsg)
+
+	type ctxType string
+
+	const ctxKey ctxType = "test-key"
+	const ctxVal ctxType = "test-value"
+	ctx := context.WithValue(context.Background(), ctxKey, ctxVal)
+
+	unmarshaled, err := m.UnmarshalWithContext(ctx, consumerMsg)
+	require.NoError(t, err)
+	require.NotNil(t, unmarshaled.Context())
+	assert.Equal(t, ctxVal, unmarshaled.Context().Value(ctxKey))
+
+	assert.True(t, msg.Equals(unmarshaled))
 }
 
 func BenchmarkDefaultMarshaler_Marshal(b *testing.B) {

--- a/pkg/kafka/subscriber.go
+++ b/pkg/kafka/subscriber.go
@@ -572,15 +572,24 @@ func (h messageHandler) processMessage(
 	ctx = setMessageTimestampToCtx(ctx, kafkaMsg.Timestamp)
 	ctx = setMessageKeyToCtx(ctx, kafkaMsg.Key)
 
-	msg, err := h.unmarshaler.Unmarshal(kafkaMsg)
+	ctx, cancelCtx := context.WithCancel(ctx)
+	defer cancelCtx()
+
+	var (
+		msg *message.Message
+		err error
+	)
+	if contextUnmarshaler, ok := h.unmarshaler.(ContextUnmarshaler); ok {
+		msg, err = contextUnmarshaler.UnmarshalWithContext(ctx, kafkaMsg)
+		ctx = msg.Context()
+	} else {
+		msg, err = h.unmarshaler.Unmarshal(kafkaMsg)
+		msg.SetContext(ctx)
+	}
 	if err != nil {
 		// resend will make no sense, stopping consumerGroupHandler
 		return errors.Wrap(err, "message unmarshal failed")
 	}
-
-	ctx, cancelCtx := context.WithCancel(ctx)
-	msg.SetContext(ctx)
-	defer cancelCtx()
 
 	receivedMsgLogFields = receivedMsgLogFields.Add(watermill.LogFields{
 		"message_uuid": msg.UUID,

--- a/pkg/kafka/subscriber_test.go
+++ b/pkg/kafka/subscriber_test.go
@@ -1,0 +1,136 @@
+package kafka_test
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/IBM/sarama"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/ThreeDotsLabs/watermill"
+	"github.com/ThreeDotsLabs/watermill-kafka/v3/pkg/kafka"
+	"github.com/ThreeDotsLabs/watermill/message"
+)
+
+type ctxType string
+
+type legacyUnmarshaler struct{}
+
+func (legacyUnmarshaler) Unmarshal(kafkaMsg *sarama.ConsumerMessage) (*message.Message, error) {
+	msg := message.NewMessage(watermill.NewUUID(), kafkaMsg.Value)
+	msg.Metadata.Set("legacy", "true")
+	return msg, nil
+}
+
+type contextAwareUnmarshaler struct{}
+
+func (contextAwareUnmarshaler) Unmarshal(kafkaMsg *sarama.ConsumerMessage) (*message.Message, error) {
+	return message.NewMessage(watermill.NewUUID(), kafkaMsg.Value), nil
+}
+
+func (contextAwareUnmarshaler) UnmarshalWithContext(ctx context.Context, kafkaMsg *sarama.ConsumerMessage) (*message.Message, error) {
+	msg := message.NewMessage(watermill.NewUUID(), kafkaMsg.Value)
+	msg.Metadata.Set("context-aware", "true")
+	ctx = context.WithValue(ctx, ctxType("int-key"), ctxType("int-value"))
+	msg.SetContext(ctx)
+	return msg, nil
+}
+
+func TestSubscriber_LegacyUnmarshaler(t *testing.T) {
+	brokers := kafkaBrokers()
+	topic := "test-legacy-" + watermill.NewShortUUID()
+
+	publisher, err := kafka.NewPublisher(
+		kafka.PublisherConfig{
+			Brokers:   brokers,
+			Marshaler: kafka.DefaultMarshaler{},
+		},
+		watermill.NewStdLogger(false, false),
+	)
+	require.NoError(t, err)
+	defer publisher.Close()
+
+	subscriber, err := kafka.NewSubscriber(
+		kafka.SubscriberConfig{
+			Brokers:       brokers,
+			Unmarshaler:   legacyUnmarshaler{},
+			ConsumerGroup: "test-legacy-group-" + watermill.NewShortUUID(),
+		},
+		watermill.NewStdLogger(false, false),
+	)
+	require.NoError(t, err)
+	defer subscriber.Close()
+
+	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
+	ctx = context.WithValue(ctx, ctxType("ext-key"), ctxType("ext-value"))
+	defer cancel()
+
+	messages, err := subscriber.Subscribe(ctx, topic)
+	require.NoError(t, err)
+
+	testMsg := message.NewMessage(watermill.NewUUID(), []byte("test payload"))
+	err = publisher.Publish(topic, testMsg)
+	require.NoError(t, err)
+
+	select {
+	case msg := <-messages:
+		assert.Equal(t, "true", msg.Metadata.Get("legacy"))
+		assert.Equal(t, "test payload", string(msg.Payload))
+		assert.Equal(t, ctxType("ext-value"), msg.Context().Value(ctxType("ext-key")))
+		msg.Ack()
+	case <-time.After(10 * time.Second):
+		t.Fatal("timeout waiting for message")
+	}
+}
+
+func TestSubscriber_ContextAwareUnmarshaler(t *testing.T) {
+	brokers := kafkaBrokers()
+	topic := "test-context-aware-" + watermill.NewShortUUID()
+
+	publisher, err := kafka.NewPublisher(
+		kafka.PublisherConfig{
+			Brokers:   brokers,
+			Marshaler: kafka.DefaultMarshaler{},
+		},
+		watermill.NewStdLogger(false, false),
+	)
+	require.NoError(t, err)
+	defer publisher.Close()
+
+	subscriber, err := kafka.NewSubscriber(
+		kafka.SubscriberConfig{
+			Brokers:       brokers,
+			Unmarshaler:   contextAwareUnmarshaler{},
+			ConsumerGroup: "test-context-group-" + watermill.NewShortUUID(),
+		},
+		watermill.NewStdLogger(false, false),
+	)
+	require.NoError(t, err)
+	defer subscriber.Close()
+
+	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
+	ctx = context.WithValue(ctx, ctxType("ext-key"), ctxType("ext-value"))
+	defer cancel()
+
+	messages, err := subscriber.Subscribe(ctx, topic)
+	require.NoError(t, err)
+
+	// Publish a test message
+	testMsg := message.NewMessage(watermill.NewUUID(), []byte("test payload"))
+	err = publisher.Publish(topic, testMsg)
+	require.NoError(t, err)
+
+	// Receive and verify message
+	select {
+	case msg := <-messages:
+		assert.Equal(t, "true", msg.Metadata.Get("context-aware"))
+		assert.Equal(t, "test payload", string(msg.Payload))
+		assert.Equal(t, ctxType("ext-value"), msg.Context().Value(ctxType("ext-key")))
+		assert.Equal(t, ctxType("int-value"), msg.Context().Value(ctxType("int-key")))
+		msg.Ack()
+	case <-time.After(10 * time.Second):
+		t.Fatal("timeout waiting for message")
+	}
+}


### PR DESCRIPTION
<!--
Thanks for contributing to Watermill!

The following template aims to help contributors write a good description for their pull requests.
**The more information you provide, the faster we will be able to review and merge your PR.**

Feel free to skip this template for minor changes like typo fixes.

-->

### Motivation / Background

This PR is to propose a solution to [this problem here](https://github.com/ThreeDotsLabs/watermill/issues/633). When unmarshaling from a Kafka message on the subscriber to a watermill message, any context set on the message would get stomped after the unmarshal method was run. 

Fixes #633

<!--

Explain the purpose of this Pull Request:
- What issue or bug does it address?
- What new functionality does it add?
- Why are these changes needed?
For bug fixes, include "Fixes #ISSUE" to automatically link to the related issue.

-->

### Details

This PR adds the following:

- adds a new interface `ContextUnmarshaler` which takes in a context for use during the unmarshal process
- updates the `DefaultMarshaler` to implement this new interface
- checks to see if the unmarshaler passed into the subscriber implements `ContextUnmarshaler` and if so - uses the context aware unmarshaling function, otherwise uses the default and preforms the stomp as previously to ensure the context still gets set.

### Alternative approaches considered (if applicable)

N/A

### Checklist

The resources of our team are limited. **There are a couple of things that you can do to help us merge your PR faster**:

- [x] I wrote tests for the changes.
- [x] All tests are passing.
  - If you are testing a Pub/Sub, you can start Docker with `make up`.
  - You can start with `make test_short` for a quick check.
  - If you want to run all tests, use `make test`.
- [x] Code has no breaking changes. (so far as I can tell)
- [ ] _(If applicable)_ documentation on [watermill.io](https://watermill.io/) is updated.
  - Documentation is built in the [github.com/ThreeDotsLabs/watermill/docs](https://github.com/ThreeDotsLabs/watermill/tree/master/docs).
  - You can find development instructions in the [DEVELOP.md](https://github.com/ThreeDotsLabs/watermill/tree/master/docs/DEVELOP.md).
